### PR TITLE
add entrypoint.sh to dockerfiles

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,1 +1,3 @@
 FROM java:7
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,1 +1,3 @@
 FROM java:8
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -1,1 +1,3 @@
 FROM java:9
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
recreating the simianarmy EB environment from scratch and the deploys to the new environment were failing, stating that an env_var was missing when the container tried to start.  It looks like the entrypoint.sh script wasn't added to this image so https://github.com/articulate/simianarmy/blob/master/Dockerfile#L1 wasn't setting any env vars from consul that were needed.  this should fix it.
